### PR TITLE
Harcodes homepage layout instead of specifying it in front matter.

### DIFF
--- a/site/.vuepress/theme/Layout.vue
+++ b/site/.vuepress/theme/Layout.vue
@@ -3,7 +3,7 @@
     <base-header />
 
     <component v-if="layout" :is="layout" />
-    <home v-else-if="$page.frontmatter.home" />
+    <!--<home v-else-if="$page.frontmatter.home" />-->
     <page v-else />
 
     <base-footer />

--- a/site/.vuepress/theme/Layout.vue
+++ b/site/.vuepress/theme/Layout.vue
@@ -17,6 +17,7 @@ export default {
   components: { Page },
   computed: {
     layout() {
+      if (this.$page.path === '/') return 'Home'
       if (this.$page.frontmatter.layout) { 
         return this.$page.frontmatter.layout 
       } else if (this.$page.path.startsWith('/blog/') && this.$page.path != '/blog/') {

--- a/site/index.md
+++ b/site/index.md
@@ -1,5 +1,4 @@
 ---
-layout: Home
 title: Kata Containers Home
 hero:
   button:


### PR DESCRIPTION
NetlifyCMS removes unknown front matter fields.
https://github.com/netlify/netlify-cms/issues/1338

If this behaviour is changed, we can revert to use either of these:
https://vuepress.vuejs.org/default-theme-config/#homepage
https://vuepress.vuejs.org/default-theme-config/#custom-layout-for-specific-pages